### PR TITLE
Fix #47 (Static class WordWrap is not stateless)

### DIFF
--- a/src/main/java/org/davidmoten/text/utils/WordWrap.java
+++ b/src/main/java/org/davidmoten/text/utils/WordWrap.java
@@ -229,6 +229,7 @@ public final class WordWrap {
          * @return this
          */
         public Builder includeExtraWordChars(String includeWordChars) {
+            copyOnWriteDefaultWordCharset();
             Set<Character> set = toSet(includeWordChars);
             this.extraWordChars.addAll(set);
             return this;
@@ -242,9 +243,19 @@ public final class WordWrap {
          * @return this
          */
         public Builder excludeExtraWordChars(String excludeWordChars) {
+            copyOnWriteDefaultWordCharset();
             Set<Character> set = toSet(excludeWordChars);
             this.extraWordChars.removeAll(set);
             return this;
+        }
+
+        /**
+         * Create a copy of extraWordChars in case it refers to SPECIAL_WORD_CHARS_SET_DEFAULT.
+         */
+        private void copyOnWriteDefaultWordCharset() {
+            if (this.extraWordChars == SPECIAL_WORD_CHARS_SET_DEFAULT) {
+                this.extraWordChars = new HashSet<>(SPECIAL_WORD_CHARS_SET_DEFAULT);
+            }
         }
 
         /**

--- a/src/test/java/org/davidmoten/text/utils/WordWrapTest.java
+++ b/src/test/java/org/davidmoten/text/utils/WordWrapTest.java
@@ -427,6 +427,13 @@ public class WordWrapTest {
     public void testNumbersWrapByDefault() {
         assertEquals("hello 12\n3", WordWrap.from("hello 123").breakWords(false).maxWidth(8).wrap());
     }
+
+    @Test
+    public void testStatelessness() {
+        assertEquals("hello super-\ncool", WordWrap.from("hello super-cool").breakWords(false).maxWidth(12).wrap());
+        assertEquals("hello\nsuper-cool", WordWrap.from("hello super-cool").breakWords(false).maxWidth(12).includeExtraWordChars("-").wrap());
+        assertEquals("hello super-\ncool", WordWrap.from("hello super-cool").breakWords(false).maxWidth(12).wrap());
+    }
     
     ////////////////////////////////////////////
     // Novel wrapping tests


### PR DESCRIPTION
Wrote a fix for bug #47.

The naming of the method is not great, but this implementation should be quite performant as it only copies the set in cases where it would otherwise be modified.